### PR TITLE
speedup: Remove lists from SpikeQueue

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "caspyan"
-version = "0.2.0"
+version = "0.2.1"
 authors = [
   { name="Kevin Zhu", email="kzhu4@gmu.edu" },
 ]

--- a/src/casPYan/edge.py
+++ b/src/casPYan/edge.py
@@ -12,7 +12,7 @@ class Edge:
 
     def step(self):
         # send spikes whose time has come
-        self.output_node.intake.add_spike(sum(self.cache[0]) * self.weight, 0)
+        self.output_node.intake.add_spike(self.cache.current * self.weight, 0)
         # count down and then forget those spikes
         self.cache.step()
 

--- a/src/casPYan/node.py
+++ b/src/casPYan/node.py
@@ -39,7 +39,7 @@ class Node:
             self.charge = self.charge * 2 ** (-1 / (2 ** self.leak))
             self.charge = int(self.charge) if self.int8 else self.charge
         # add/integrate charge from spikes if they've just "arrived"
-        self.charge += sum(self.intake[0])
+        self.charge += self.intake.current
         # and then delete those spikes from cache
         self.intake.step()
 

--- a/src/casPYan/util.py
+++ b/src/casPYan/util.py
@@ -43,8 +43,7 @@ class SpikeQueue:
             self.add_spike(value, time + self.t)
         elif isinstance(time, slice):
             for i in range(0, time.stop)[time]:
-                i += self.t
-                self.spikes[i] = value[i]
+                self.spikes[i + self.t] = value[i]
         else:
             self.spikes[time + self.t] = value
 
@@ -117,7 +116,8 @@ class SpikeQueue:
                 del self.spikes[self.t]
             self.t += 1
         else:
-            del self.spikes[self.t : self.t + dt]
+            if delete:
+                del self[self.t : self.t + dt]
             self.t += dt
 
     @property

--- a/src/casPYan/util.py
+++ b/src/casPYan/util.py
@@ -22,35 +22,41 @@ class SpikeQueue:
         elif isinstance(spikes, dict):
             self.spikes = spikes
         elif isinstance(spikes, list):
-            pass
-
-        self.spikes = spikes or {}
-
-    def __getitem__(self, key):
-        if isinstance(key, int):
-            return self.spikes.get(key, [])
-        elif isinstance(key, slice):
-            return [self.spikes.get(i, []) for i in range(0, key.stop)[key]]
+            self.spikes = {}
+            self.add_spikes(spikes)
         else:
-            return self.spikes.get(key, [])
+            msg = f"Cannot initialize {self} with {spikes} of type {type(spikes)}"
+            raise ValueError(msg)
+
+        self.t = 0
+
+    def __getitem__(self, key) -> float:
+        if isinstance(key, int):
+            return self.spikes.get(key + self.t, 0.0)
+        elif isinstance(key, slice):
+            return [self.spikes.get(i + self.t, 0.0) for i in range(0, key.stop)[key]]
+        else:
+            return self.spikes.get(key, 0.0)
 
     def __setitem__(self, time, value):
         if isinstance(time, int):
-            self.add_spike(value, time)
+            self.add_spike(value, time + self.t)
         elif isinstance(time, slice):
             for i in range(0, time.stop)[time]:
+                i += self.t
                 self.spikes[i] = value[i]
         else:
-            self.spikes[time] = value
+            self.spikes[time + self.t] = value
 
     def add_spike(self, value: float, time: int = 0):
         if time < 0:
             msg = f"Cannot queue spike {time} time steps in the past to {self}"
             raise ValueError(msg)
+        time += self.t
         if time in self.spikes:
-            self.spikes[time].append(value)
+            self.spikes[time] += value
         else:
-            self.spikes[time] = [value]
+            self.spikes[time] = value
 
     def add_spikes(self, spikes: list[tuple[float, int]] | dict[float, int]):
         if isinstance(spikes, dict):
@@ -60,10 +66,11 @@ class SpikeQueue:
 
     def __delitem__(self, key):
         if isinstance(key, int):
-            del self.spikes[key]
+            del self.spikes[key + self.t]
         elif isinstance(key, slice):
             for i in range(0, key.stop)[key]:
-                del self.spikes[i]
+                if i + self.t in self.spikes:
+                    del self.spikes[i + self.t]
         else:
             del self.spikes[key]
 
@@ -77,7 +84,7 @@ class SpikeQueue:
         return f"{self.__class__.__name__} at {id(self):x} with {len(self)} spikes"
 
     def __contains__(self, key):
-        return key in self.spikes
+        return key + self.t in self.spikes
 
     def __eq__(self, value):
         return self.spikes == value
@@ -91,29 +98,42 @@ class SpikeQueue:
             new.add_spikes(value.spikes if isinstance(value, SpikeQueue) else value)
             return new
         else:
-            raise ValueError(f"Cannot add {value} of type {type(value)} to {self}")
+            msg = f"Cannot add {value} of type {type(value)} to {self}"
+            raise ValueError(msg)
 
     def __iadd__(self, value):
         if isinstance(value, (SpikeQueue, dict, list)):
             self.add_spikes(value.spikes if isinstance(value, SpikeQueue) else value)
             return self
         else:
-            raise ValueError(f"Cannot add {value} of type {type(value)} to {self}")
+            msg = f"Cannot add {value} of type {type(value)} to {self}"
+            raise ValueError(msg)
 
     def step(self, dt: int = 1, delete: bool = True):
         if dt == 0:
             return
         if dt == 1:
-            if 0 in self.spikes and delete:
-                del self.spikes[0]
-            self.spikes = {k - 1: v for k, v in self.spikes.items()}
+            if delete and self.t in self.spikes:
+                del self.spikes[self.t]
+            self.t += 1
         else:
-            self.spikes = {k - dt: v for k, v in self.spikes.items() if not delete or (k - dt) >= 0}
+            del self.spikes[self.t : self.t + dt]
+            self.t += dt
+
+    @property
+    def current(self):
+        return self.spikes.get(self.t, 0.0)
+
+    def __call__(self, dt: int = 1, delete: bool = True):
+        temp = self[0:dt]
+        self.step(dt, delete)
+        return temp
 
     def append(self, value):
         if isinstance(value, (tuple, list)):
             self.add_spike(*value)
         elif isinstance(value, numbers.Real):
-            self.add_spike(0, value)
+            self.add_spike(float(value), 0)
         else:
-            raise ValueError(f"Cannot append {value} of type {type(value)} to {self}")
+            msg = f"Cannot append {value} of type {type(value)} to {self}"
+            raise ValueError(msg)


### PR DESCRIPTION
SpikeQueue now stores a single `float` value for each future timestep, instead of a `list[float]`.

API Change:
The internal `SpikeQueue.spikes` now stores an absolute value for timestep rather than a relative value, and the class now keeps track of its current absolute timestep with `SpikeQueue.t`. That is, `SpikeQueue[0]` now references `SpikeQueue.spikes[SpikeQueue.t]`, and `SpikeQueue.step()` increments `SpikeQueue.t` by `+1`.

These two changes net me an approximately 50% speedup in fps in RSS with six agents.

